### PR TITLE
fix small and lazy electroncash.org nav ui bug, remove nav bar resize animation on scrolling (It's called Bitcoin stable after all!) + 3 other line alters

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -30,8 +30,8 @@ button{
 .erasable-header {
   position: fixed;
   width: 100%;
-  margin-top: -3.5rem;
-  padding-top: 50px;
+  margin: 0;
+  padding: 1rem 0 0 0;
   transition: 0.7s all;
   z-index: 100;
   background-color: #162d50;
@@ -56,7 +56,7 @@ button{
 .shrink{
   position: fixed;
   width: 100%;
-  padding-top: 20px;
+  padding: 1rem 0 0 0;
   transition: 0.7s all;
   z-index: 100;
   background-color: #162d50;

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
 <body id="body">
   <header id="topnav">
-    <div class="erasable-header shrink">
+    <div class="erasable-header">
       <div class="container">
       <div class="row links">
         <div class="five columns left">
@@ -365,7 +365,7 @@ Oregano release 4.3.4: &nbsp;&nbsp;<BR>
           <BR><b> OpenAlias (for XRG, BCH, XMR, BTC): donate@ergon.moe </b>
           <BR><b><a href="ergon:qz449vfh5fjk5sv36jq4z9n9d6xuag4l0utau0kz6z" >ergon:qz449vfh5fjk5sv36jq4z9n9d6xuag4l0utau0kz6z<a></b>
           <BR><b><a href="bitcoincash:qr6alaul372f6lq7sj2svdlpxdthvdlgwcxnqys8xr">bitcoincash:qr6alaul372f6lq7sj2svdlpxdthvdlgwcxnqys8xr</a></b>
-          <BR><par style=wraplong>XMR: <b>88ySe8XvLsx1x7kC6Qv1a8498iSxmudCZSuyDbPUpjAshbB5CGmNz2AhSnvGiBUyWDUbkGWFRbmWqc1MKLfGoyAdGxxMr7V </b></par>
+          <BR><par style="overflow-wrap: break-word">XMR: <b>88ySe8XvLsx1x7kC6Qv1a8498iSxmudCZSuyDbPUpjAshbB5CGmNz2AhSnvGiBUyWDUbkGWFRbmWqc1MKLfGoyAdGxxMr7V </b></par>
           <BR>ETH/ERC20: <b>0x3B6C45c656d59C36B943c4AFD95a0a42153307C8</b>
           <BR>DOGE: <b>DUNh7P3divupqhPxrYG7xsBnEiCFAvZYxf</b>
           <BR>BTC: <b>bc1qquzawfknxpf4lu22vwznakwpgn7xpqr7lucnpx</b></p>
@@ -377,13 +377,13 @@ Oregano release 4.3.4: &nbsp;&nbsp;<BR>
 
 
       <div class="row">
-        <h6 style="font-size: 1.75rem;">    <a href="https://github.com/Ergon-moe/Bitcoin-Static">Explore Source Code</a> | <a href="http://www.reddit.com/r/ergon">Ergon Forum</a>
+        <h6 style="font-size: 1.75rem">    <a href="https://github.com/Ergon-moe/Bitcoin-Static">Explore Source Code</a> | <a href="http://www.reddit.com/r/ergon">Ergon Forum</a>
 
         </h6>
       </div>
 
  <div class="row">
-        <h6 style="font-size: 1.75rem;">
+        <h6 style="font-size: 1.75rem">
           <a href="https://explorer.ergon.network">Block Explorer </a>
 </h6>
         </h6>


### PR DESCRIPTION
fast fix through css, without removing the js resizing which could be reused in the future, ideally the nav bar would be rewritten cause it's not easy to adjust or restyle it (the way the desktop version is written), eg: not easy to adjust bottom padding or margins under the nav links currently